### PR TITLE
Custom Interceptors for Address Cache

### DIFF
--- a/src/address/address.cache.interceptor.ts
+++ b/src/address/address.cache.interceptor.ts
@@ -1,0 +1,41 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Inject,
+} from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+@Injectable()
+export class AddressCacheInterceptor implements NestInterceptor {
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+
+  getCacheKey(context: ExecutionContext): string {
+    const request = context.switchToHttp().getRequest();
+    const address = request.params.address;
+    return `address:${address}`;
+  }
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<any>> {
+    const key = this.getCacheKey(context);
+    const ttl = 30; // cache time to live in seconds
+
+    const cachedResponse = await this.cacheManager.get(key);
+    if (cachedResponse) {
+      return of(cachedResponse);
+    }
+
+    return next.handle().pipe(
+      tap(async (response) => {
+        await this.cacheManager.set(key, response, ttl);
+      }),
+    );
+  }
+}

--- a/src/address/address.controller.ts
+++ b/src/address/address.controller.ts
@@ -2,15 +2,14 @@ import { Controller, Get, Param } from '@nestjs/common';
 import { AddressService } from './address.service';
 import { CacheInterceptor, CacheKey, CacheTTL } from '@nestjs/cache-manager';
 import { Body, UseInterceptors } from '@nestjs/common/decorators';
+import { AddressCacheInterceptor } from './address.cache.interceptor';
 
 @Controller('address')
-@UseInterceptors(CacheInterceptor)
+@UseInterceptors(AddressCacheInterceptor)
 export class AddressController {
   constructor(private readonly addressService: AddressService) {}
 
   @Get('/:address')
-  @CacheKey('address')
-  @CacheTTL(30)
   async getAddress(@Param() address: string) {
     return this.addressService.getAddressSummary(address);
   }


### PR DESCRIPTION
introduces the cache interceptor pattern to cache certain endpoints that are computationally expensive. 