### PR TITLE
Feature: Electrum API

### DIFF
--- a/apps/bitcoin-analytics-api/src/address/address.controller.ts
+++ b/apps/bitcoin-analytics-api/src/address/address.controller.ts
@@ -2,9 +2,9 @@ import { Controller, Get, Param } from '@nestjs/common';
 import { AddressService } from './address.service';
 import { UseInterceptors } from '@nestjs/common/decorators';
 import { AddressCacheInterceptor } from './address.cache.interceptor';
+import { ElectrumService } from '../electrum/electrum.service';
 
 @Controller('address')
-@UseInterceptors(AddressCacheInterceptor)
 export class AddressController {
   constructor(private readonly addressService: AddressService) {}
 

--- a/apps/bitcoin-analytics-api/src/address/address.module.ts
+++ b/apps/bitcoin-analytics-api/src/address/address.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AddressService } from './address.service';
 import { AddressController } from './address.controller';
 import { BitcoindModule } from '../bitcoind/bitcoin.module';
+import { ElectrumModule } from '../electrum/electrum.module';
 
 @Module({
-  imports: [BitcoindModule],
+  imports: [BitcoindModule, ElectrumModule],
   controllers: [AddressController],
   providers: [AddressService],
 })

--- a/apps/bitcoin-analytics-api/src/address/address.service.ts
+++ b/apps/bitcoin-analytics-api/src/address/address.service.ts
@@ -1,49 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { DataSource } from 'typeorm';
+import { ElectrumService } from '../electrum/electrum.service';
 
 @Injectable()
 export class AddressService {
-  constructor(private readonly dataSource: DataSource) {}
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly electrumService: ElectrumService,
+  ) {}
 
   async getAddressSummary(addressObj): Promise<any> {
     const address = addressObj.address;
 
-    const query = `
-    SELECT
-        JSON_OBJECT(
-            'address', ?,
-            'transactions', (
-                SELECT JSON_ARRAYAGG(
-                    JSON_OBJECT(
-                        'id', t.id,
-                        'txid', t.txid,
-                        'hash', t.hash,
-                        'size', t.size,
-                        'vsize', t.vsize,
-                        'weight', t.weight,
-                        'locktime', t.locktime,
-                        'blockId', t.blockId,
-                        'time', b.time,
-                        'blocktime', b.time
-                    )
-                )
-                FROM transactions t
-                JOIN blocks b ON t.blockId = b.id
-                WHERE t.id IN (
-                    SELECT transactionId FROM transaction_outputs WHERE scriptPubKeyAddress = ?
-                    UNION
-                    SELECT i.transactionId FROM transaction_inputs i
-                    JOIN transaction_outputs o ON i.txid = o.transactionId AND i.vout = o.n
-                    WHERE o.scriptPubKeyAddress = ?
-                )
-            )
-        ) AS summary
-    `;
+    const addressTransactions =
+      await this.electrumService.getBlockHeight(address);
 
-    const parameters = [address, address, address];
-
-    const rawResults = await this.dataSource.query(query, parameters);
-
-    return rawResults.map((row) => row.summary);
+    return addressTransactions;
   }
 }

--- a/apps/bitcoin-analytics-api/src/app.module.ts
+++ b/apps/bitcoin-analytics-api/src/app.module.ts
@@ -14,6 +14,7 @@ import { RedisOptions } from './config/redis.config';
 import { LndModule } from './lnd/lnd.module';
 import { LightningModule } from './lightning/lightning.module';
 import { WinstonModule } from 'nest-winston';
+import { ElectrumModule } from './electrum/electrum.module';
 import * as winston from 'winston';
 
 @Module({
@@ -52,6 +53,7 @@ import * as winston from 'winston';
     AddressModule,
     LndModule,
     LightningModule,
+    ElectrumModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/bitcoin-analytics-api/src/electrum/electrum.module.ts
+++ b/apps/bitcoin-analytics-api/src/electrum/electrum.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ElectrumService } from './electrum.service';
+
+@Module({
+  providers: [ElectrumService],
+  exports: [ElectrumService],
+})
+export class ElectrumModule {}

--- a/apps/bitcoin-analytics-api/src/electrum/electrum.service.ts
+++ b/apps/bitcoin-analytics-api/src/electrum/electrum.service.ts
@@ -1,0 +1,150 @@
+import axios from 'axios';
+import { ConfigService } from '@nestjs/config';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ElectrumService {
+  constructor(private readonly configService: ConfigService) {}
+
+  private async makeRequest(endpoint: string): Promise<any> {
+    const baseUrl = this.configService.get('ELECTRUM_HOST');
+    const url = baseUrl + endpoint;
+
+    try {
+      const response = await axios.get(url);
+      return response.data;
+    } catch (error) {
+      throw new Error(`Error while making request to ${url}: ${error.message}`);
+    }
+  }
+
+  async getAddress(address: string) {
+    const endpoint = `/address/${address}`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getAddressTransactions(address: string) {
+    const endpoint = `/address/${address}/txs`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getAddressTransactionsChain(address: string) {
+    const endpoint = `/address/${address}/txs/chain`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getAddresstransactionsMempool(address: string) {
+    const endpoint = `/address/${address}/txs/mempool`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getAddressUtxos(address: string) {
+    const endpoint = `/address/${address}/utxo`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getBlock(blockHash: string) {
+    const endpoint = `/block/${blockHash}`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getBlockHeader(blockHash: string) {
+    const endpoint = `/block/${blockHash}/header`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getBlockHeight(blockHeight: number) {
+    const endpoint = `/block-height/${blockHeight}`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getBlockRaw(blockHash: string) {
+    const endpoint = `/block/${blockHash}/raw`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getblockStatus(blockHash: string) {
+    const endpoint = `/block/${blockHash}/status`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getBlockTipHeight() {
+    const endpoint = '/block/tip/height';
+    return await this.makeRequest(endpoint);
+  }
+
+  async getBlockTipHash() {
+    const endpoint = '/block/tip/hash';
+    return await this.makeRequest(endpoint);
+  }
+
+  async getBlockTransactionId(blockHash: string, index: number) {
+    const endpoint = `/block/${blockHash}/txid/${index}`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getBlockTransactionIds(blockHash: string) {
+    const endpoint = `/block/${blockHash}/txids`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getBlockTransactions(blockHash: string) {
+    const endpoint = `/block/${blockHash}/txs`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getMempool() {
+    const endpoint = '/mempool';
+    return await this.makeRequest(endpoint);
+  }
+
+  async getMempoolTransactionIds() {
+    const endpoint = '/mempool/txids';
+    return await this.makeRequest(endpoint);
+  }
+
+  async getMempoolRecent() {
+    const endpoint = '/mempool/recent';
+    return await this.makeRequest(endpoint);
+  }
+
+  async getTransaction(txid: string) {
+    const endpoint = `/tx/${txid}`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getTransactionHex(txid: string) {
+    const endpoint = `/tx/${txid}/hex`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getTransactionMerkleblockProof(txid: string) {
+    const endpoint = `/tx/${txid}/merkleblock-proof`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getTransactionMerkleProof(txid: string) {
+    const endpoint = `/tx/${txid}/merkle-proof`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getTransactionOutspender(txid: string, index: number) {
+    const endpoint = `/tx/${txid}/outspend/${index}`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getTransactionOutspends(txid: string) {
+    const endpoint = `/tx/${txid}/outspends`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getTransactionRaw(txid: string) {
+    const endpoint = `/tx/${txid}/raw`;
+    return await this.makeRequest(endpoint);
+  }
+
+  async getTransactionStatus(txid: string) {
+    const endpoint = `/tx/${txid}/status`;
+    return await this.makeRequest(endpoint);
+  }
+}

--- a/apps/bitcoin-analytics-api/src/main.ts
+++ b/apps/bitcoin-analytics-api/src/main.ts
@@ -12,7 +12,7 @@ async function bootstrap() {
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
-  await app.listen(3000);
+  await app.listen(3005);
   console.log(`Application is running on: ${await app.getUrl()}`);
 }
 bootstrap();


### PR DESCRIPTION
Uses the Electrs REST API to get data, simple API wrapper as the electrum service.

With this we should be able to remove all references to Bitcoin Core.

TODO: Response Types